### PR TITLE
Allow Transaction type override

### DIFF
--- a/typings/objection/index.d.ts
+++ b/typings/objection/index.d.ts
@@ -1107,7 +1107,7 @@ declare namespace Objection {
     result?: R;
   }
 
-  export type Transaction = Knex.Transaction;
+  export interface Transaction extends Knex.Transaction {}
   export type TransactionOrKnex = Transaction | Knex;
 
   export interface RelationMappings {


### PR DESCRIPTION
In Objection v2 `Transaction` switched from being `interface` to `type`.
Since we add our own functionality to Objection, we need a way to override it:

```typescript
declare module 'objection' {
  interface Transaction {
    fooBar(): boolean;
  }
}
```

In this PR we go back to declaring `Transaction` as an `interface`.
Unfortunately that's the only way I found.