### PR TITLE
expand allowed types for tableRefFor and tableNameFor

### DIFF
--- a/typings/objection/index.d.ts
+++ b/typings/objection/index.d.ts
@@ -613,7 +613,7 @@ declare namespace Objection {
   }
 
   interface TableRefForMethod {
-    (modelClass: typeof Model): string;
+    (modelClass: ModelClass<Model> | typeof Model): string;
   }
 
   interface AliasForMethod<QB extends AnyQueryBuilder> {


### PR DESCRIPTION
It fixes:
```
TS2345: Argument of type 'ModelClass<any>' is not assignable to parameter of type 'typeof Model'.
```


for cases like:
```typescript
query.tableRefFor(query.modelClass());
```