### PR TITLE
fix: losing aliasMap in 'partial' subqueries

### DIFF
--- a/lib/queryBuilder/QueryBuilderOperationSupport.js
+++ b/lib/queryBuilder/QueryBuilderOperationSupport.js
@@ -1,6 +1,6 @@
 'use strict';
 
-const { isString, isFunction, isRegExp, last } = require('../utils/objectUtils');
+const { isString, isFunction, isRegExp, mergeMaps, last } = require('../utils/objectUtils');
 const { QueryBuilderContextBase } = require('./QueryBuilderContextBase');
 const { QueryBuilderUserContext } = require('./QueryBuilderUserContext');
 const { deprecate } = require('../utils/deprecate');
@@ -177,6 +177,14 @@ class QueryBuilderOperationSupport {
 
   subqueryOf(query) {
     if (query) {
+      if (this._isPartialQuery) {
+        // Merge alias and table name maps for "partial" subqueries.
+        const ctx = this.internalContext();
+
+        ctx.aliasMap = mergeMaps(query.internalContext().aliasMap, ctx.aliasMap);
+        ctx.tableMap = mergeMaps(query.internalContext().tableMap, ctx.tableMap);
+      }
+
       this._parentQuery = query;
 
       if (this.unsafeKnex() === null) {

--- a/lib/queryBuilder/operations/ObjectionToKnexConvertingOperation.js
+++ b/lib/queryBuilder/operations/ObjectionToKnexConvertingOperation.js
@@ -131,7 +131,7 @@ function convertFunction(func, builder) {
 function convertQueryBuilderFunction(knexQueryBuilder, func, builder) {
   const convertedQueryBuilder = builder.constructor.forClass(builder.modelClass());
 
-  convertedQueryBuilder.subqueryOf(builder).isPartial(true);
+  convertedQueryBuilder.isPartial(true).subqueryOf(builder);
   func.call(convertedQueryBuilder, convertedQueryBuilder);
 
   convertedQueryBuilder.toKnexQuery(knexQueryBuilder);
@@ -141,7 +141,7 @@ function convertJoinBuilderFunction(knexJoinBuilder, func, builder) {
   const JoinBuilder = getJoinBuilder();
   const joinClauseBuilder = JoinBuilder.forClass(builder.modelClass());
 
-  joinClauseBuilder.subqueryOf(builder).isPartial(true);
+  joinClauseBuilder.isPartial(true).subqueryOf(builder);
   func.call(joinClauseBuilder, joinClauseBuilder);
 
   joinClauseBuilder.toKnexQuery(knexJoinBuilder);

--- a/lib/utils/objectUtils.js
+++ b/lib/utils/objectUtils.js
@@ -373,6 +373,18 @@ function isSafeKey(key) {
   return isNumber(key) || (isString(key) && key !== '__proto__');
 }
 
+function mergeMaps(map1, map2) {
+  const map = new Map(map1);
+
+  if (map2) {
+    for (let key of map2.keys()) {
+      map.set(key, map2.get(key));
+    }
+  }
+
+  return map;
+}
+
 module.exports = {
   isEmpty,
   isString,
@@ -385,6 +397,7 @@ module.exports = {
   difference,
   upperFirst,
   zipObject,
+  mergeMaps,
   cloneDeep,
   asSingle,
   asArray,


### PR DESCRIPTION
This fixes an issue with 'partial' subqueries that they lose `aliasMap` from `q._context` (QueryBuilder's "internal context") while generating nested `where` sql part. `QueryBuilder.subqueryOf()` used to grab context from "parent" query, but it doesn't anymore. (since 2019-02-13) https://github.com/Vincit/objection.js/commit/524e0bef5f75a280aa54d1ee30b6b36c304ea6ad

In our case, we were getting SQL errors where alias was necessary to make it work, but it was missing
```
ER_NON_UNIQ_ERROR: Column 'event_id' in IN/ALL/ANY subquery is ambiguous
```


Basically reintroducing what was deleted in https://github.com/Vincit/objection.js/commit/524e0bef5f75a280aa54d1ee30b6b36c304ea6ad (to fix https://github.com/Vincit/objection.js/issues/1205) but wrap merging context with a condition that it should only apply to "partial" subqueries + reverse the sequence that `isPartial()` is set before `subqueryOf()`