### PR TITLE
fix typings for PartialModelGraph and nullable fields

### DIFF
--- a/typings/objection/index.d.ts
+++ b/typings/objection/index.d.ts
@@ -222,14 +222,18 @@ declare namespace Objection {
    * Just like PartialModelObject but this is applied recursively to relations.
    */
   type PartialModelGraph<M, T = M & GraphParameters> = {
-    [K in DataPropertyNames<T>]?: Defined<T[K]> extends Model
-      ? PartialModelGraph<Defined<T[K]>>
-      : Defined<T[K]> extends Array<infer I>
+    [K in DataPropertyNames<T>]?: null extends T[K]
+      ? PartialModelGraphField<NonNullable<T[K]>> | null // handle nullable BelongsToOneRelations
+      : PartialModelGraphField<T[K]>;
+  };
+
+  type PartialModelGraphField<F> = Defined<F> extends Model
+    ? PartialModelGraph<Defined<F>>
+    : Defined<F> extends Array<infer I>
       ? I extends Model
         ? PartialModelGraph<I>[]
-        : Expression<T[K]>
-      : Expression<T[K]>;
-  };
+        : Expression<F>
+      : Expression<F>;
 
   /**
    * Extracts the property names (excluding relations) of a model class.


### PR DESCRIPTION
Handle `| null` unions properly. (e.g. for nullable `BelongsToOneRelations`).

Before `PartialModelGraph` was converting `field: Model | null;` to `field?: Expression<Model | null>`, and typescript throws errors for graphs with partial sub-graphs for those nullable relations. (expecting full instance of the model class)
Now it converts it properly to `field?: PartialModelGraph<Model> | null` 🎉